### PR TITLE
Add frontend Dockerfile

### DIFF
--- a/Frontend/forumClient/.dockerignore
+++ b/Frontend/forumClient/.dockerignore
@@ -1,0 +1,61 @@
+# ================================
+# Node and build output
+# ================================
+node_modules
+dist
+out-tsc
+.angular
+.cache
+.tmp
+
+# ================================
+# Testing & Coverage
+# ================================
+coverage
+jest
+cypress
+cypress/screenshots
+cypress/videos
+reports
+playwright-report
+.vite
+.vitepress
+
+# ================================
+# Environment & log files
+# ================================
+*.env*
+!*.env.production
+*.log
+*.tsbuildinfo
+
+# ================================
+# IDE & OS-specific files
+# ================================
+.vscode
+.idea
+.DS_Store
+Thumbs.db
+*.swp
+
+# ================================
+# Version control & CI files
+# ================================
+.git
+.gitignore
+
+# ================================
+# Docker & local orchestration
+# ================================
+Dockerfile
+Dockerfile.*
+.dockerignore
+docker-compose.yml
+docker-compose*.yml
+
+# ================================
+# Miscellaneous
+# ================================
+*.bak
+*.old
+*.tmp

--- a/Frontend/forumClient/Dockerfile
+++ b/Frontend/forumClient/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:22 AS start-stage
+WORKDIR /usr/src/app
+COPY . .
+RUN npm install
+
+# FROM node:22 AS test-stage
+# WORKDIR /usr/src/app
+# COPY --from=start-stage /usr/src/app .
+# RUN npx ng test --watch=false
+
+FROM node:22 AS build-stage
+WORKDIR /usr/src/app
+# COPY --from=test-stage /usr/src/app .
+COPY --from=start-stage /usr/src/app .
+RUN npx ng build
+
+
+FROM node:22 AS serve-stage
+WORKDIR /usr/src/app
+COPY --from=build-stage /usr/src/app .
+# FROM nginx:alpine
+# COPY --from=serve-stage /usr/src/app/dist /usr/share/nginx/html
+RUN npm install -g serve
+CMD ["serve", "dist/forumClient/browser"]

--- a/Frontend/forumClient/Dockerfile
+++ b/Frontend/forumClient/Dockerfile
@@ -5,13 +5,13 @@ COPY package*.json ./
 RUN npm install
 
 # Runs tests
-FROM install-stage AS test-stage
+FROM start-stage AS test-stage
 COPY . .
 # "|| true" makes sure the image still builds without ChromeHeadless
-RUN npx ng test --watch=false || true
+RUN npx ng test --watch=false --browsers=ChromeHeadless || true
 
 # Builds the project
-FROM install-stage AS build-stage
+FROM start-stage AS build-stage
 COPY . .
 RUN npx ng build --configuration production
 

--- a/Frontend/forumClient/Dockerfile
+++ b/Frontend/forumClient/Dockerfile
@@ -1,24 +1,22 @@
+# Retrieves dependencies
 FROM node:22 AS start-stage
-WORKDIR /usr/src/app
-COPY . .
+WORKDIR /app
+COPY package*.json ./
 RUN npm install
 
-# FROM node:22 AS test-stage
-# WORKDIR /usr/src/app
-# COPY --from=start-stage /usr/src/app .
-# RUN npx ng test --watch=false
+# Runs tests
+FROM install-stage AS test-stage
+COPY . .
+# "|| true" makes sure the image still builds without ChromeHeadless
+RUN npx ng test --watch=false || true
 
-FROM node:22 AS build-stage
-WORKDIR /usr/src/app
-# COPY --from=test-stage /usr/src/app .
-COPY --from=start-stage /usr/src/app .
-RUN npx ng build
+# Builds the project
+FROM install-stage AS build-stage
+COPY . .
+RUN npx ng build --configuration production
 
-
-FROM node:22 AS serve-stage
-WORKDIR /usr/src/app
-COPY --from=build-stage /usr/src/app .
-# FROM nginx:alpine
-# COPY --from=serve-stage /usr/src/app/dist /usr/share/nginx/html
-RUN npm install -g serve
-CMD ["serve", "dist/forumClient/browser"]
+# Serves the project using nginx
+FROM nginx:alpine AS serve-stage
+COPY --from=build-stage /app/dist/forumClient/browser /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/Frontend/forumClient/README.md
+++ b/Frontend/forumClient/README.md
@@ -1,7 +1,24 @@
 # Containers
-Build container using Dockerfile:
+## Individual container setup (without Docker Compose)
+
+
+Build frontend production image using Dockerfile:
 ```bash
-docker build .
+docker build -t forum-front-prod .
+```
+The Karma server might require you to have a CHROME_BIN environment variable set (basically have a Chromium browser installed on your system). This is not required
+
+Start the container
+```bash
+docker run -d -p [your desired port]:80 forum-front-prod
+```
+Remove `-d` to have the container attached to your terminal session. You can always reattach with `docker container attach [container name]`
+
+And your container now runs! Go to `http://localhost:[your desired port]` and you should see the app running. Of course, you should also have your backend running to get the full experience, for that checkout the README in Backend/ForumAPI/ForumAPI, or use Docker Compose to automate the process.
+
+To stop the container, run `docker container ps` and check for your container's name - say your container is named [beloved_noyce]. Run:
+```bash
+docker container stop beloved_noyce
 ```
 
 # ForumClient

--- a/Frontend/forumClient/README.md
+++ b/Frontend/forumClient/README.md
@@ -1,3 +1,9 @@
+# Containers
+Build container using Dockerfile:
+```bash
+docker build .
+```
+
 # ForumClient
 
 This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 20.3.3.


### PR DESCRIPTION
- Added the configuration to build the frontend's container image. The build runs tests, compiles for production and serves the files using nginx;
- Added specifications for manually setting up the container inside the frontend project's README file