### PR TITLE
Configure containers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# fill in the fields in an unversioned .env file
+# cat .env.example > .env
+POSTGRES_PASSWORD=
+POSTGRES_USER=
+POSTGRES_DB=
+ConnectionStrings__Default=
+JWTSettings__SecretKey=

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 ################################################################################
 
 /Backend/ForumAPI/ForumAPI/appsettings.Development.json
+.env

--- a/Backend/ForumAPI/.gitignore
+++ b/Backend/ForumAPI/.gitignore
@@ -427,3 +427,5 @@ FodyWeavers.xsd
 *.msm
 *.msp
 appsettings.Development.json
+
+.idea/*

--- a/Backend/ForumAPI/ForumAPI/README.md
+++ b/Backend/ForumAPI/ForumAPI/README.md
@@ -1,8 +1,6 @@
-**For Docker**
-
-*Production*
-
-Provide a connection string in `appsettings.json`
+# Forum API
+## Setup
+Provide a connection string in either `appsettings.json` or `appsettings.Development.json`, depending on if you start the API in production or development mode:
 
 ```json
 {
@@ -14,10 +12,40 @@ Provide a connection string in `appsettings.json`
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "ForumContext": "Host=localhost;Database=forum;Username={{ USERNAME }};Password={{ PASSWORD }};TrustServerCertificate=True;Pooling=True;"
+    "ForumContext": "Host=localhost;Database=forum;Username={{ USERNAME }};Password={{ PASSWORD }};Pooling=True;"
   }
 }
 ```
+
+# Containers
+## Individual container setup (without Docker Compose)
+
+Build frontend production image using Dockerfile:
+```bash
+docker build -t forum-back-prod .
+```
+
+Start the container
+```bash
+docker run -d -p [your desired port]:80 forum-back-prod
+```
+Remove `-d` to have the container attached to your terminal session. You can always reattach with `docker container attach [container name]`
+
+To run properly, the container needs to attach to a PostgreSQL database. For easier usage, use Docker Compose with the configurations attached in the root of the repository.
+
+To stop the container, run `docker container ps` and check for your container's name - say your container is named [beloved_noyce]. Run:
+```bash
+docker container stop beloved_noyce
+```
+
+To start the development containers you would do the same thing, only difference is that now you should specify the dockerfile to be `dev.Dockerfile`:
+```bash
+docker build -t forum-back-dev --file dev.Dockerfile .
+docker run -d -p [your desired port]:80 forum-back-dev
+```
+
+*Production*
+
 
 Build the image
 ```bash

--- a/Backend/ForumAPI/ForumAPI/dev.Dockerfile
+++ b/Backend/ForumAPI/ForumAPI/dev.Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0
+WORKDIR /app
+COPY ["ForumAPI.csproj", "./"]
+RUN dotnet restore
+COPY . .
+EXPOSE 8080
+CMD ["dotnet", "watch", "run", "--urls", "http://0.0.0.0:8080"]

--- a/Frontend/forumClient/README.md
+++ b/Frontend/forumClient/README.md
@@ -21,6 +21,12 @@ To stop the container, run `docker container ps` and check for your container's 
 docker container stop beloved_noyce
 ```
 
+To start the development containers you would do the same thing, only difference is that now you should specify the dockerfile to be `dev.Dockerfile`:
+```bash
+docker build -t forum-front-dev --file dev.Dockerfile .
+docker run -d -p [your desired port]:80 forum-front-dev
+```
+
 # ForumClient
 
 This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 20.3.3.

--- a/Frontend/forumClient/dev.Dockerfile
+++ b/Frontend/forumClient/dev.Dockerfile
@@ -1,0 +1,10 @@
+# Dockerfile for development - see reference at https://docs.docker.com/guides/angular/develop/
+
+FROM node:22 AS dev
+ENV NODE_ENV=development
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+EXPOSE 4200
+CMD ["npm", "start", "--", "--host=0.0.0.0"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,49 @@
+services:
+  # database
+  database:
+    image: postgres:latest
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: 1q2w3e
+      POSTGRES_DB: forum
+    ports:
+      - "5432:5432"
+    volumes:
+      - database-data:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # server
+  backend:
+      image: forum-back-dev
+      build:
+        context: ./Backend/ForumAPI/ForumAPI
+        dockerfile: dev.Dockerfile
+      volumes:
+        - ./Backend/ForumAPI/ForumAPI:/app
+      ports:
+        - "7151:8080"
+      container_name: forum-back-container
+      depends_on:
+        - database
+      environment:
+        ConnectionStrings__Default: "Host=database;Database=forum;Username=postgres;Password=1q2w3e;Pooling=True;"
+        JWTSettings__SecretKey: "86fbda2aae8013c4f1fef2e18c49b4b643bc2b30b72611edbc778fe822a22bdc"
+
+  # client
+  frontend:
+    image: forum-front-dev
+    build:
+      context: ./Frontend/forumClient
+      dockerfile: dev.Dockerfile
+    volumes:
+      - ./Frontend/forumClient:/app
+    ports:
+      - 4200:80
+    container_name: forum-front-container
+
+volumes:
+  database-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+services:
+  # database
+  database:
+    image: postgres:latest
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    ports:
+      - "5432:5432"
+    volumes:
+      - database-data:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # server
+  backend:
+      image: forum-back-prod
+      build:
+        context: ./Backend/ForumAPI/ForumAPI
+        dockerfile: Dockerfile
+      ports:
+        - "7151:8080"
+      container_name: forum-back-container
+      depends_on:
+        - database
+      environment:
+        ConnectionStrings__Default: ${ConnectionStrings__Default}
+        JWTSettings__SecretKey: ${JWTSettings__SecretKey}
+
+  # client
+  frontend:
+    image: forum-front-prod
+    build:
+      context: ./Frontend/forumClient
+      dockerfile: Dockerfile
+    ports:
+      - "4200:80"
+    container_name: forum-front-container
+    
+volumes:
+  database-data:


### PR DESCRIPTION
Development containers don't test, compile and serve each project, instead they run both of them with hot module replacement for fast responses to code changes when files are updated.
- forum-front-dev and forum-back-dev containers, alongside the PostgreSQL database container can be managed through the `docker-compose.dev.yml` file in the root of the project. Docker compose allocates volumes for ease of use and avoid unnecessary rebuilds;
- Frontend runs on port 4200, backend on port 7151;
- Environment variables are directly inlined for convenience - in the production containers they will not be exposed;
- Added specifications for manual use in the README's of each project

EDIT: I also added to this branch the configurations for production, so I guess it also contains them too.
- The production containers are configured to use environment variables. Assign them using a `.env` file filled with given template `.env.example`